### PR TITLE
fix(balance): you don't really need the balance check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,77 @@
+sudo: required
+dist: xenial # (16.04)
+# bionic (18.04) is not yet available in travis
+
+language: cpp
+
+cache: ccache
+
+addons:
+  apt:
+    update: true
+
+services:
+  - mysql
+
+git:
+  depth: 10
+
+stages:
+  - prepare_cache
+  - run
+
+jobs:
+  include:
+    - stage: prepare_cache
+      env: TRAVIS_BUILD_ID="1"
+      before_install:
+        - cd ..
+        - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
+        - mv "$TRAVIS_BUILD_DIR" azerothcore-wotlk/modules
+        - cd azerothcore-wotlk
+        - source ./apps/ci/ci-before_install.sh
+      install:
+        - source ./apps/ci/ci-install.sh OFF
+      script:
+        - source ./apps/ci/ci-compile.sh
+
+    - stage: run
+      env: TRAVIS_BUILD_ID="1"
+      before_install:
+        - cd ..
+        - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
+        - mv "$TRAVIS_BUILD_DIR" azerothcore-wotlk/modules
+        - cd azerothcore-wotlk
+        - source ./apps/ci/ci-before_install.sh
+      install:
+        - source ./apps/ci/ci-install.sh ON
+        - source ./apps/ci/ci-import-db.sh
+      script:
+        - source ./apps/ci/ci-compile.sh
+        - source ./apps/ci/ci-worldserver-dry-run.sh
+
+    - stage: prepare_cache
+      env: TRAVIS_BUILD_ID="2"
+      before_install:
+        - cd ..
+        - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
+        - mv "$TRAVIS_BUILD_DIR" azerothcore-wotlk/modules
+        - cd azerothcore-wotlk
+        - source ./apps/ci/ci-before_install.sh
+      install:
+        - source ./apps/ci/ci-install.sh OFF
+      script:
+        - source ./apps/ci/ci-compile.sh
+
+    - stage: run
+      env: TRAVIS_BUILD_ID="2"
+      before_install:
+        - cd ..
+        - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
+        - mv "$TRAVIS_BUILD_DIR" azerothcore-wotlk/modules
+        - cd azerothcore-wotlk
+        - source ./apps/ci/ci-before_install.sh
+      install:
+        - source ./apps/ci/ci-install.sh ON
+      script:
+        - source ./apps/ci/ci-compile.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ![logo](https://raw.githubusercontent.com/azerothcore/azerothcore.github.io/master/images/logo-github.png) AzerothCore module
-
+- Latest build status with azerothcore: [![Build Status](https://travis-ci.org/azerothcore/mod-cfbg.svg?branch=master)](https://travis-ci.org/azerothcore/mod-cfbg)
 # CrossFaction Battleground
 
 ### Module currently requires:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 # CrossFaction Battleground
 
 ### Module currently requires:
-* **MODULE DON'T SUPPORT FOR AC OFFICIALLY NEED TEST THIS PR'S**
-* * https://github.com/azerothcore/azerothcore-wotlk/pull/2064
+* Need AC commit [`d40e8946`](https://github.com/azerothcore/azerothcore-wotlk/commit/d40e8946180129b39172c2a1b4d690aa71723917) or newer.
 
 ## About module
 This module based patch https://gist.github.com/irancore/10913800. 
@@ -29,6 +28,7 @@ But, all mechanics of change of fraction and so on is remade. Faction change occ
 
 CFBG.Enable = 1
 CFBG.Include.Avg.Ilvl.Enable = 1
+CFBG.Players.Count.In.Group = 3
 ```
 
 ### How to install

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -481,6 +481,7 @@ void CFBG::UpdateForget(Player* player)
     }
 }
 
+std::unordered_map<uint64, uint32> BGSpam;
 bool CFBG::SendMessageQueue(BattlegroundQueue* bgqueue, Battleground* bg, PvPDifficultyEntry const* bracketEntry, Player* leader)
 {
     if (!IsEnableSystem())
@@ -497,7 +498,18 @@ bool CFBG::SendMessageQueue(BattlegroundQueue* bgqueue, Battleground* bg, PvPDif
     if (sWorld->getBoolConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_PLAYERONLY))
         ChatHandler(leader->GetSession()).PSendSysMessage("CFBG %s (Levels: %u - %u). Registered: %u/%u", bgName, q_min_level, q_max_level, qPlayers, MinPlayers);
     else
-        sWorld->SendWorldText(LANG_BG_QUEUE_ANNOUNCE_WORLD, bgName, q_min_level, q_max_level, qPlayers, MinPlayers);
-
+    {
+        auto searchGUID = BGSpam.find(leader->GetGUID());
+        
+        if (searchGUID == BGSpam.end())
+            BGSpam[leader->GetGUID()] = 0;
+        
+        if (sWorld->GetGameTime() - BGSpam[leader->GetGUID()] >= 30)
+        {
+            BGSpam[leader->GetGUID()] = sWorld->GetGameTime();
+            sWorld->SendWorldText(LANG_BG_QUEUE_ANNOUNCE_WORLD, bgName, q_min_level, q_max_level, qPlayers, MinPlayers);
+        }
+    }
+        
     return true;
 }

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -366,41 +366,6 @@ bool CFBG::FillPlayersToCFBGWithSpecific(BattlegroundQueue* bgqueue, Battlegroun
     BattlegroundQueue::GroupsQueueType::const_iterator Horde_itr = m_QueuedBoth[TEAM_HORDE].begin();
     for (; Horde_itr != m_QueuedBoth[TEAM_HORDE].end() && bgqueue->m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeFree); ++Horde_itr);
 
-    // calculate free space after adding
-    int32 aliDiff = aliFree - int32(bgqueue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount());
-    int32 hordeDiff = hordeFree - int32(bgqueue->m_SelectionPools[TEAM_HORDE].GetPlayerCount());
-
-    // if free space differs too much, ballance
-    while (abs(aliDiff - hordeDiff) > 1 && (bgqueue->m_SelectionPools[TEAM_HORDE].GetPlayerCount() > 0 || bgqueue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount() > 0))
-    {
-        // if results in more alliance players than horde:
-        if (aliDiff < hordeDiff)
-        {
-            // no more alliance in pool, invite whatever we can from horde
-            if (!bgqueue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount())
-                break;
-
-            // kick alliance, returns true if kicked more than needed, so then try to fill up
-            if (bgqueue->m_SelectionPools[TEAM_ALLIANCE].KickGroup(hordeDiff - aliDiff))
-                for (; Ali_itr != m_QueuedBoth[TEAM_ALLIANCE].end() && bgqueue->m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Ali_itr), aliFree >= hordeDiff ? aliFree - hordeDiff : 0); ++Ali_itr);
-        }
-        // if results in more horde players than alliance:
-        else
-        {
-            // no more horde in pool, invite whatever we can from alliance
-            if (!bgqueue->m_SelectionPools[TEAM_HORDE].GetPlayerCount())
-                break;
-
-            // kick horde, returns true if kicked more than needed, so then try to fill up
-            if (bgqueue->m_SelectionPools[TEAM_HORDE].KickGroup(aliDiff - hordeDiff))
-                for (; Horde_itr != m_QueuedBoth[TEAM_HORDE].end() && bgqueue->m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeFree >= aliDiff ? hordeFree - aliDiff : 0); ++Horde_itr);
-        }
-
-        // recalculate free space after adding
-        aliDiff = aliFree - int32(bgqueue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount());
-        hordeDiff = hordeFree - int32(bgqueue->m_SelectionPools[TEAM_HORDE].GetPlayerCount());
-    }
-
     return true;
 }
 
@@ -425,40 +390,6 @@ bool CFBG::FillPlayersToCFBG(BattlegroundQueue* bgqueue, Battleground* bg, const
     // horde: at first fill as much as possible
     BattlegroundQueue::GroupsQueueType::const_iterator Horde_itr = bgqueue->m_QueuedGroups[bracket_id][BG_QUEUE_CFBG].begin();
     for (; Horde_itr != bgqueue->m_QueuedGroups[bracket_id][BG_QUEUE_CFBG].end() && bgqueue->m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeFree); ++Horde_itr);
-
-    // calculate free space after adding
-    int32 aliDiff = aliFree - int32(bgqueue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount());
-    int32 hordeDiff = hordeFree - int32(bgqueue->m_SelectionPools[TEAM_HORDE].GetPlayerCount());
-
-    // if free space differs too much, ballance
-    while (abs(aliDiff - hordeDiff) > 1 && (bgqueue->m_SelectionPools[TEAM_HORDE].GetPlayerCount() > 0 || bgqueue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount() > 0))
-    {
-        // if results in more alliance players than horde:
-        if (aliDiff < hordeDiff)
-        {
-            // no more alliance in pool, invite whatever we can from horde
-            if (!bgqueue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount())
-                break;
-
-            // kick alliance, returns true if kicked more than needed, so then try to fill up
-            if (bgqueue->m_SelectionPools[TEAM_ALLIANCE].KickGroup(hordeDiff - aliDiff))
-                for (; Ali_itr != bgqueue->m_QueuedGroups[bracket_id][BG_QUEUE_CFBG].end() && bgqueue->m_SelectionPools[TEAM_ALLIANCE].AddGroup((*Ali_itr), aliFree >= hordeDiff ? aliFree - hordeDiff : 0); ++Ali_itr);
-        }        
-        else // if results in more horde players than alliance:
-        {
-            // no more horde in pool, invite whatever we can from alliance
-            if (!bgqueue->m_SelectionPools[TEAM_HORDE].GetPlayerCount())
-                break;
-
-            // kick horde, returns true if kicked more than needed, so then try to fill up
-            if (bgqueue->m_SelectionPools[TEAM_HORDE].KickGroup(aliDiff - hordeDiff))
-                for (; Horde_itr != bgqueue->m_QueuedGroups[bracket_id][BG_QUEUE_CFBG].end() && bgqueue->m_SelectionPools[TEAM_HORDE].AddGroup((*Horde_itr), hordeFree >= aliDiff ? hordeFree - aliDiff : 0); ++Horde_itr);
-        }
-
-        // recalculate free space after adding
-        aliDiff = aliFree - int32(bgqueue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount());
-        hordeDiff = hordeFree - int32(bgqueue->m_SelectionPools[TEAM_HORDE].GetPlayerCount());
-    }
 
     return true;
 }

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -143,7 +143,7 @@ public:
             sCFBG->FitPlayerInTeam(player, player->GetBattleground() && !player->GetBattleground()->isArena() ? true : false, player->GetBattleground());
     }
 
-    bool CanJoinInBattlegroundQueue(Player* player, uint64 BattlemasterGuid, BattlegroundTypeId BGTypeID, uint8 joinAsGroup, GroupJoinBattlegroundResult& err) override
+    bool CanJoinInBattlegroundQueue(Player* player, uint64 /*BattlemasterGuid*/ , BattlegroundTypeId /*BGTypeID*/, uint8 joinAsGroup, GroupJoinBattlegroundResult& err) override
     {
         if (!sCFBG->IsEnableSystem())
             return true;
@@ -174,7 +174,7 @@ public:
             timeCheck -= diff;
     }
 
-    void OnBeforeSendChatMessage(Player* player, uint32& type, uint32& lang, std::string& msg) override
+    void OnBeforeSendChatMessage(Player* player, uint32& type, uint32& lang, std::string& /*msg*/) override
     {
         if (!player || !sCFBG->IsEnableSystem())
             return;

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -80,7 +80,7 @@ public:
             sCFBG->ClearFakePlayer(player);
     }
 
-    void OnAddGroup(BattlegroundQueue* queue, GroupQueueInfo* ginfo, uint32& index, Player* /*leader*/, Group* /*grp*/, PvPDifficultyEntry const* /*bracketEntry*/, bool /*isPremade*/)
+    void OnAddGroup(BattlegroundQueue* queue, GroupQueueInfo* ginfo, uint32& index, Player* /*leader*/, Group* /*grp*/, PvPDifficultyEntry const* /*bracketEntry*/, bool /*isPremade*/) override
     {
         if (!queue)
             return;


### PR DESCRIPTION
The CFBG doesn't need to know which is the difference between the ally and the horde team during the "Filling" process.

At that time we're only checking if there's room for players on specific BG.

Later on, this instruction https://github.com/Yehonal/mod-cfbg/blob/master/src/CFBG_SC.cpp#L31 will shuffle the queue to the team with fewer players, regardless if they are horde or ally originally.

With that check instead, you generate this issue: https://github.com/azerothcore/mod-cfbg/issues/11

